### PR TITLE
use previous codemeta entry if possible and if the repo itself doesn'…

### DIFF
--- a/R/codemeta.R
+++ b/R/codemeta.R
@@ -1,4 +1,22 @@
 .create_cm <- function(pkg, org, old_cm){
+
+  if(!is.null(old_cm)){
+    if(length(old_cm[purrr::map_chr(old_cm, "identifier") ==
+                     gsub("repos\\/.*\\/", "", pkg)]) > 0){
+      old_entry <- old_cm[purrr::map_chr(old_cm, "identifier") ==
+               gsub("repos\\/.*\\/", "", pkg)][[1]]
+
+      if (!file.exists(file.path(pkg, "codemeta.json"))){
+        jsonlite::write_json(old_entry, path = file.path(pkg, "codemeta.json"))
+
+      }
+    } else {
+      old_entry <- NULL
+    }
+  } else {
+      old_entry <- NULL
+    }
+
   info <- try(codemetar::create_codemeta(pkg = pkg, verbose = FALSE,
                                          force_update = TRUE),
               silent = TRUE)
@@ -13,13 +31,9 @@
   }else{
     print(toupper(pkg))
 
-    if(!is.null(old_cm)){
-      if(length(old_cm[purrr::map_chr(old_cm, "identifier") ==
-                       gsub("repos\\/.*\\/", "", pkg)]) > 0){
-        old_cm[purrr::map_chr(old_cm, "identifier") ==
-                 gsub("repos\\/.*\\/", "", pkg)][[1]]
-
-      }else{
+    if (is.null(old_entry)){
+      return(old_entry)
+      } else {
         NULL
       }
     }else{

--- a/R/codemeta.R
+++ b/R/codemeta.R
@@ -8,7 +8,7 @@
 
       if (!file.exists(file.path(pkg, "codemeta.json"))){
         jsonlite::write_json(old_entry, path = file.path(pkg, "codemeta.json"))
-
+        codemeta_written <- TRUE
       }
     } else {
       old_entry <- NULL
@@ -20,7 +20,12 @@
   info <- try(codemetar::create_codemeta(pkg = pkg, verbose = FALSE,
                                          force_update = TRUE),
               silent = TRUE)
-  if(!inherits(info, "try-error")){
+
+  if (codemeta_written) {
+    file.remove(file.path(pkg, "codemeta.json"))
+  }
+
+  if(!inherits(info, "try-error")) {
     # for other repos, the URLs in DESCRIPTION have to be right
     if(org %in% c("ropensci", "ropenscilabs")){
       info$codeRepository <- paste0("https://github.com/",


### PR DESCRIPTION
…t have one

cf #6 

Currently, if we can't for whatever reason create a codemeta.json for the `foo` folder, we return the previous entry from the big codemeta file if there's one entry, i.e. the codemeta JSON of `foo` within "raw_cm.json". That's good but we want more robustness.

We should have `codemetar` itself to also use that entry if it exists: this way `codemetar` updates information instead of creating from scratch. The only way to make `codemetar` _update_ codemeta.json rather than create it from scratch is to have a codemeta.json file in the `foo` folder. 

So this PR creates the codemeta.json file in the `foo` folder if there's no such file (we want to give priority to the codemeta.json the authors added, hopefully up to date) and if there's a previous entry. This way if GitHub API is not reachable, we'll obtain a codemeta JSON for `foo` with the keywords from the previous entry rather than no keywors.

@sckott if that's unclear you can ask questions either here or on our next call.

I'm not sure how you could actually test it. 